### PR TITLE
Add resolution scaling parameter

### DIFF
--- a/anim.py
+++ b/anim.py
@@ -48,7 +48,7 @@ def split_str_into_newlines(text: str,font_path,font_size):
 
 
 # @profile
-def do_video(config: List[Dict], output_filename):
+def do_video(config: List[Dict], output_filename, resolution_scale):
     scenes = []
     sound_effects = []
     part = 0
@@ -285,13 +285,13 @@ def do_video(config: List[Dict], output_filename):
                 sound_effects.append({"_type": "silence", "length": _length})
                 current_frame += _length
             if (len(scenes) > 50):
-                video = AnimVideo(scenes, fps=fps)
+                video = AnimVideo(scenes, fps=fps, resolution_scale=resolution_scale)
                 video.render(output_filename + '/' +str(part) + '.mp4')
                 part+=1
                 scenes = []
 
     if (len(scenes) > 0):
-        video = AnimVideo(scenes, fps=fps)
+        video = AnimVideo(scenes, fps=fps, resolution_scale=resolution_scale)
         video.render(output_filename + '/' +str(part) + '.mp4')
     return sound_effects
 
@@ -354,14 +354,14 @@ def do_audio(sound_effects: List[Dict], output_filename):
     final_se = music_se.overlay(audio_se)
     final_se.export(output_filename, format="mp3")
 
-def ace_attorney_anim(config: List[Dict], output_filename: str = "output.mp4"):
+def ace_attorney_anim(config: List[Dict], output_filename: str = "output.mp4", resolution_scale: int = 1):
     root_filename = output_filename[:-4]
     audio_filename = output_filename + '.audio.mp3'
     text_filename = root_filename + '.txt'
     if os.path.exists(root_filename):
         shutil.rmtree(root_filename)
     os.mkdir(root_filename)
-    sound_effects = do_video(config, root_filename)
+    sound_effects = do_video(config, root_filename, resolution_scale)
     do_audio(sound_effects, audio_filename)
     videos = []
     with open(text_filename, 'w') as txt:

--- a/beans/video.py
+++ b/beans/video.py
@@ -32,7 +32,6 @@ class AnimVideo:
                 if(self.resolution_scale > 1):
                     # use cv2.resize to scale the frame with integer scaling
                     cv2_frame = cv2.resize(cv2_frame, (0, 0), fx=self.resolution_scale, fy=self.resolution_scale, interpolation=cv2.INTER_NEAREST)
-                    # frame = cv2.resize(frame, frame.size * self.resolution_scale, interpolation=cv2.INTER_NEAREST)
                 video.write(cv2_frame)
         video.release()
         return output_path

--- a/beans/video.py
+++ b/beans/video.py
@@ -6,9 +6,10 @@ import numpy as np
 import random
 
 class AnimVideo:
-    def __init__(self, scenes: List[scene.AnimScene], fps: int = 10):
+    def __init__(self, scenes: List[scene.AnimScene], fps: int = 10, resolution_scale: int = 1):
         self.scenes = scenes
         self.fps = fps
+        self.resolution_scale = resolution_scale
     # @profile
     def render(self, output_path: str = None):
         if output_path is None:
@@ -21,9 +22,17 @@ class AnimVideo:
         background = self.scenes[0].frames[0]
         if os.path.isfile(output_path):
             os.remove(output_path)
-        video = cv2.VideoWriter(output_path, fourcc, self.fps, background.size)
+        video_dimensions = background.size
+        if self.resolution_scale != 1:
+            video_dimensions = (background.size[0] * self.resolution_scale, background.size[1] * self.resolution_scale)
+        video = cv2.VideoWriter(output_path, fourcc, self.fps, video_dimensions)
         for scene in self.scenes:
             for frame in scene.frames:
-                video.write(cv2.cvtColor(np.array(frame), cv2.COLOR_RGB2BGR))
+                cv2_frame = cv2.cvtColor(np.array(frame), cv2.COLOR_RGB2BGR)
+                if(self.resolution_scale > 1):
+                    # use cv2.resize to scale the frame with integer scaling
+                    cv2_frame = cv2.resize(cv2_frame, (0, 0), fx=self.resolution_scale, fy=self.resolution_scale, interpolation=cv2.INTER_NEAREST)
+                    # frame = cv2.resize(frame, frame.size * self.resolution_scale, interpolation=cv2.INTER_NEAREST)
+                video.write(cv2_frame)
         video.release()
         return output_path

--- a/renderer.py
+++ b/renderer.py
@@ -10,7 +10,7 @@ from utils import ensure_assets_are_available
 import requests
 
 
-def render_comment_list(comment_list: List[Comment], output_filename = 'hello.mp4', music_code = 'PWR'):
+def render_comment_list(comment_list: List[Comment], output_filename = 'hello.mp4', music_code = 'PWR', resolution_scale: int = 1):
     ensure_assets_are_available()
     try: 
         collect_stats()
@@ -27,7 +27,7 @@ def render_comment_list(comment_list: List[Comment], output_filename = 'hello.mp
         thread.append(CommentBridge(comment))
     if (output_filename[-4:] != '.mp4'):
         output_filename += '.mp4'
-    return anim.comments_to_scene(thread, name_music = music_code, output_filename=output_filename)
+    return anim.comments_to_scene(thread, name_music = music_code, output_filename=output_filename, resolution_scale=resolution_scale)
 
 def process_music_code(music_code):
     music_code = music_code.lower()


### PR DESCRIPTION
On Discord (and likely other platforms), the relatively low resolution of the video can make embeds small and lead to blurriness when in fullscreen.

Although more complex solutions have been outlined in #12, this is a quick & easy way to make the video more high resolution without losing sharpness by just using nearest neighbor scaling.

Scaling is passed through the `resolution_scale` parameter in the `render_comment_list` method. Old scaling (1:1) is retained by default

![Discord Example](https://user-images.githubusercontent.com/34404266/163730117-b320d8c2-5361-48c6-838b-5c2c14d525d2.png)
