### PR TITLE
Allow user to manually assign characters to user IDs

### DIFF
--- a/manual_character_example.py
+++ b/manual_character_example.py
@@ -1,0 +1,32 @@
+from objection_engine.renderer import render_comment_list
+from objection_engine.beans.comment import Comment
+from objection_engine.constants import Character
+from time import time
+
+comments = [
+    Comment(user_name = "User 1", text_content="I'm Phoenix even though I don't talk much", user_id="a"),
+    
+    Comment(user_name = "User 4", text_content="No idea who I am, I'm not specified", user_id="d"),
+    Comment(user_name = "User 4", text_content="I'm gonna talk a little bit more though", user_id="d"),
+
+    Comment(user_name = "User 2", text_content="I'm Payne instead of Edgeworth, and I talk a little bit.", user_id="b"),
+    Comment(user_name = "User 2", text_content="Here I am talking some more.", user_id="b"),
+    Comment(user_name = "User 2", text_content="And a little bit more", user_id="b"),
+    
+    Comment(user_name = "User 3", text_content="I'm Redd White, some random guy, even though I talk the most", user_id="c"),
+    Comment(user_name = "User 3", text_content="Lorem ipsum dolor sit amet, consectetur adipiscing elit.", user_id="c"),
+
+    Comment(user_name = "User 5", text_content="Hey don't forget about me! whoever I am", user_id="e"),
+
+    Comment(user_name = "User 3", text_content="Nunc aliquet et justo elementum mollis. Nullam commodo nisl id accumsan gravida.", user_id = "c"),
+    Comment(user_name = "User 3", text_content="Vivamus elementum mattis ipsum, ac luctus lacus scelerisque lacinia.", user_id = "c"),
+    Comment(user_name = "User 3", text_content="Vivamus elementum mattis ipsum, ac luctus lacus scelerisque lacinia.", user_id = "c")
+]
+
+characters = {
+    Character.PHOENIX: "a",
+    Character.PAYNE: "b",
+    Character.REDD: "c"
+}
+
+render_comment_list(comments, f'output-manual-character-{str(int(time()))}.mp4', resolution_scale=2, assigned_characters=characters)

--- a/manual_character_example.py
+++ b/manual_character_example.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from objection_engine.renderer import render_comment_list
 from objection_engine.beans.comment import Comment
 from objection_engine.constants import Character
@@ -24,9 +25,11 @@ comments = [
 ]
 
 characters = {
-    Character.PHOENIX: "a",
-    Character.PAYNE: "b",
-    Character.REDD: "c"
+    "a": Character.PHOENIX,
+    "b": Character.PAYNE,
+    "c": Character.REDD
 }
 
-render_comment_list(comments, f'output-manual-character-{str(int(time()))}.mp4', resolution_scale=2, assigned_characters=characters)
+t = datetime.now().strftime("%Y%m%dT%H%M%S")
+render_comment_list(comments, f'output-{t}-auto.mp4', resolution_scale=2)
+render_comment_list(comments, f'output-{t}-manual.mp4', resolution_scale=2, assigned_characters=characters)

--- a/objection_engine/renderer.py
+++ b/objection_engine/renderer.py
@@ -10,7 +10,7 @@ from .utils import ensure_assets_are_available
 import requests
 
 
-def render_comment_list(comment_list: List[Comment], output_filename: str = 'hello.mp4', music_code: str = 'PWR', resolution_scale: int = 1):
+def render_comment_list(comment_list: List[Comment], output_filename: str = 'hello.mp4', music_code: str = 'PWR', resolution_scale: int = 1, assigned_characters: dict = None):
     """
     Given a list of Comments, writes a resulting video to disk at the
     location specified by `output_filename`.
@@ -26,6 +26,10 @@ def render_comment_list(comment_list: List[Comment], output_filename: str = 'hel
     - "TAT" uses music from "Trials and Tribulations"
     - "RND" chooses a random game
     :param int resolution_scale: How much to scale the outputted video by
+    :param list[dict] assigned_characters: A dictionary with Character keys \
+        and string user ID values that manually assign a given user to be portrayed \
+        by a specific character. Any users who do not have a character \
+        assigned to them via this dictionary will have one assigned at random.
     """
     ensure_assets_are_available()
     try:
@@ -40,7 +44,7 @@ def render_comment_list(comment_list: List[Comment], output_filename: str = 'hel
     counter = Counter()
     for comment in comment_list:
         counter.update({comment.effective_user_id: 1})
-    characters = get_characters(counter)
+    characters = get_characters(counter, assigned_characters=assigned_characters)
 
     # Construct the information about the sequence of "shots" in
     # the finished video (e.g. the text spoken and which character

--- a/objection_engine/renderer.py
+++ b/objection_engine/renderer.py
@@ -26,8 +26,8 @@ def render_comment_list(comment_list: List[Comment], output_filename: str = 'hel
     - "TAT" uses music from "Trials and Tribulations"
     - "RND" chooses a random game
     :param int resolution_scale: How much to scale the outputted video by
-    :param list[dict] assigned_characters: A dictionary with Character keys \
-        and string user ID values that manually assign a given user to be portrayed \
+    :param list[dict] assigned_characters: A dictionary with string user ID keys \
+        and Character values that manually assign a given user to be portrayed \
         by a specific character. Any users who do not have a character \
         assigned to them via this dictionary will have one assigned at random.
     """

--- a/objection_engine/utils.py
+++ b/objection_engine/utils.py
@@ -17,12 +17,7 @@ def ensure_assets_are_available():
         os.remove('assets.zip')
 
 def get_characters(common: Counter, assigned_characters: dict = None):
-    if assigned_characters is None:
-        assigned_characters = {}
-    else:
-        assigned_characters = assigned_characters.copy()
-
-    users_to_characters = {}
+    users_to_characters = {} if assigned_characters is None else assigned_characters.copy()
     most_common =  [t[0] for t in common.most_common()]
     all_rnd_characters = [
         Character.GODOT,
@@ -45,37 +40,25 @@ def get_characters(common: Counter, assigned_characters: dict = None):
         Character.REDD,
     ]
 
-    # If Phoenix was manually assigned, then assign him to his user.
-    # Otherwise, assign him to the user with the most comments.
-    if Character.PHOENIX in assigned_characters:
-        users_to_characters[assigned_characters[Character.PHOENIX]] = Character.PHOENIX
-        del assigned_characters[Character.PHOENIX]
-    else:
+    # If Phoenix was not manually assigned and the user with
+    # the most comments wasn't manually assigned a character,
+    # assign Phoenix to the user with the most comments.
+    if Character.PHOENIX not in users_to_characters.values() and most_common[0] not in users_to_characters:
         try:
             users_to_characters[most_common[0]] = Character.PHOENIX
         except IndexError:
             pass
 
-    # Same for Edgeworth, but in the case of no manual assignment,
-    # assign him to the user with the second-most comments.
-    if Character.EDGEWORTH in assigned_characters:
-        users_to_characters[assigned_characters[Character.EDGEWORTH]] = Character.EDGEWORTH
-        del assigned_characters[Character.EDGEWORTH]
-    else:
+    # Same for Edgeworth, but to the user with the second-most comments.
+    if Character.EDGEWORTH not in users_to_characters.values() and most_common[1] not in users_to_characters:
         try:
             users_to_characters[most_common[1]] = Character.EDGEWORTH
         except IndexError:
             pass
 
-    # Before we start randomly assigning characters, let's match up all of the
-    # manually assigned characters to their user IDs.
-    for character, user_id in assigned_characters.items():
-        users_to_characters[user_id] = character
-        all_rnd_characters.remove(character)
-
     # Finally, from the remaining pool of characters, let's assign them randomly
     # to the remaining user IDs.
-    rnd_characters = []
+    rnd_characters = [c for c in all_rnd_characters if c not in users_to_characters.values()]
     for user_id in most_common:
         # Skip users who were manually assigned characters.
         if user_id in users_to_characters:

--- a/objection_engine/utils.py
+++ b/objection_engine/utils.py
@@ -40,6 +40,12 @@ def get_characters(common: Counter, assigned_characters: dict = None):
         Character.REDD,
     ]
 
+    # Confirm that all of the assigned characters are valid.
+    all_characters = all_rnd_characters + [Character.PHOENIX, Character.EDGEWORTH]
+    for character in users_to_characters.values():
+        if character not in all_characters:
+            raise ValueError(f"\"{character}\" is not a valid character")
+
     # If Phoenix was not manually assigned and the user with
     # the most comments wasn't manually assigned a character,
     # assign Phoenix to the user with the most comments.


### PR DESCRIPTION
Implements #48. The optional parameter `assigned_characters` has been added to the `render_comment_list()` function. Each key is a character (like `Character.PHOENIX`) and its value is the `user_id` that the character will portray.


I've included the script `manual_character_example.py` that demonstrates this. When the `characters` dictionary in that script is commented out/not sent to `render_comment_list()`, this is the resulting video:

https://user-images.githubusercontent.com/9957987/197287044-ee486cc5-e704-4c07-9d6c-1b9829d564b5.mp4

Here's the same dialogue but with the `characters` passed to `render_comment_list()` (what you'd get if you ran the script):

https://user-images.githubusercontent.com/9957987/197286610-a4ef1eb9-0ff0-48bf-8d28-1eb38401584a.mp4

The `get_characters()` function inside of `utils.py` had to be reworked a bit to allow for this; while the testing I did was successful, it might be good to have someone else confirm that the logic looks good before merging.

Thanks!






