### PR TITLE
Nameplate changes width to fit name and uses different font

### DIFF
--- a/objection_engine/anim.py
+++ b/objection_engine/anim.py
@@ -60,7 +60,8 @@ def do_video(config: List[Dict], output_filename, resolution_scale):
         # We pick up the images to be rendered
         bg = AnimImg(constants.location_map[scene["location"]])
         arrow = AnimImg("assets/arrow.png", x=235, y=170, w=15, h=15, key_x=5)
-        textbox = AnimImg("assets/textbox4.png", w=bg.w)
+        textbox = AnimImg("assets/textbox/mainbox.png", x=1, y=129, w=bg.w-2)
+        namebox_l = AnimImg("assets/textbox/nametag_left.png", x=1, y=129-12)
         objection = AnimImg("assets/objection.gif")
         bench = None
 
@@ -169,13 +170,31 @@ def do_video(config: List[Dict], output_filename, resolution_scale):
 
                 # Draw the user's name above the text box
                 _character_name = character_name
+                _namebox_center = None
+                _namebox_right = None
                 if "name" in obj:
                     _character_name = AnimText(
                         obj["name"],
                         font_path="assets/igiari/Igiari.ttf",
                         font_size=12,
-                        x=4,
-                        y=113,
+                        x=6,
+                        y=129-11,
+                    )
+
+                    name_width = _character_name.get_text_size()[0]
+
+                    _namebox_center = AnimImg(
+                        "assets/textbox/nametag_center.png",
+                        x=3,
+                        y=129-12,
+                        w=name_width + 6,
+                        h=14
+                    )
+
+                    _namebox_right = AnimImg(
+                        "assets/textbox/nametag_right.png",
+                        x=3 + name_width + 6,
+                        y=129-12
                     )
 
                 # Apply shake effect to the scene if desired
@@ -189,7 +208,7 @@ def do_video(config: List[Dict], output_filename, resolution_scale):
                 scene_objs = list(
                     filter(
                         lambda x: x is not None,
-                        [bg, character, bench, textbox, _character_name, text, evidence],
+                        [bg, character, bench, textbox, namebox_l, _namebox_center, _namebox_right, _character_name, text, evidence],
                     )
                 )
                 scenes.append(

--- a/objection_engine/anim.py
+++ b/objection_engine/anim.py
@@ -20,7 +20,7 @@ import spacy
 from .polarity_analysis import Analizer
 analizer = Analizer()
 from .beans.img import AnimImg
-from .beans.text import AnimText
+from .beans.text import AnimText, TextType
 from .beans.scene import AnimScene
 from .beans.video import AnimVideo
 from .constants import Character, lag_frames, fps
@@ -56,8 +56,8 @@ def create_nameplate(obj: dict):
     if "name" not in obj: return []
     character_name = AnimText(
         obj["name"],
-        font_path = "assets/igiari/Igiari.ttf",
-        font_size = 12,
+        text_type=TextType.NAME,
+        font_size = 8,
         x = 6,
         y = 129 - 11
     )
@@ -138,13 +138,6 @@ def do_video(config: List[Dict], output_filename, resolution_scale):
                 _dir = constants.character_map[obj["character"]]
                 current_character_name = obj["character"]
                 current_character_gender = constants.character_gender_map[obj["character"]]
-                character_name = AnimText(
-                    current_character_name,
-                    font_path="assets/igiari/Igiari.ttf",
-                    font_size=12,
-                    x=4,
-                    y=113,
-                )
                 default = "normal" if "emotion" not in obj else obj["emotion"]
                 default_path = (
                     f"{_dir}/{current_character_name.lower()}-{default}(a).gif"
@@ -201,10 +194,9 @@ def do_video(config: List[Dict], output_filename, resolution_scale):
                 _colour = None if "colour" not in obj else obj["colour"]
                 text = AnimText(
                     _text,
-                    font_path="assets/igiari/Igiari.ttf",
                     font_size=15,
-                    x=5,
-                    y=130,
+                    x=11,
+                    y=134,
                     typewriter_effect=True,
                     colour=_colour,
                 )

--- a/objection_engine/anim.py
+++ b/objection_engine/anim.py
@@ -48,6 +48,49 @@ def split_str_into_newlines(text: str, font_path, font_size):
     words = text.split(" ")
     return fit_words_within_width(words, font, True)
 
+def create_nameplate(obj: dict):
+    """
+    Creates the layers for a nameplate that
+    resizes to fit the user's name.
+    """
+    if "name" not in obj: return []
+    character_name = AnimText(
+        obj["name"],
+        font_path = "assets/igiari/Igiari.ttf",
+        font_size = 12,
+        x = 6,
+        y = 129 - 11
+    )
+
+    name_width = character_name.get_text_size()[0]
+
+    namebox_l = AnimImg(
+        "assets/textbox/nametag_left.png",
+        x = 1,
+        y = 129 - 12
+    )
+
+    namebox_c = AnimImg(
+        "assets/textbox/nametag_center.png",
+        x = 3,
+        y = 129-12,
+        w = name_width + 6,
+        h = 14
+    )
+
+    namebox_r = AnimImg(
+        "assets/textbox/nametag_right.png",
+        x = 3 + name_width + 6,
+        y = 129 - 12
+    )
+
+    if obj.get("action") == constants.Action.TEXT_SHAKE_EFFECT:
+        namebox_l.shake_effect = True
+        namebox_c.shake_effect = True
+        namebox_r.shake_effect = True
+
+    return [namebox_l, namebox_c, namebox_r, character_name]
+
 def do_video(config: List[Dict], output_filename, resolution_scale):
     """
     Renders the video, and returns a list of sound effects that can be used to
@@ -61,7 +104,6 @@ def do_video(config: List[Dict], output_filename, resolution_scale):
         bg = AnimImg(constants.location_map[scene["location"]])
         arrow = AnimImg("assets/arrow.png", x=235, y=170, w=15, h=15, key_x=5)
         textbox = AnimImg("assets/textbox/mainbox.png", x=1, y=129, w=bg.w-2)
-        namebox_l = AnimImg("assets/textbox/nametag_left.png", x=1, y=129-12)
         objection = AnimImg("assets/objection.gif")
         bench = None
 
@@ -168,35 +210,6 @@ def do_video(config: List[Dict], output_filename, resolution_scale):
                 )
                 num_frames = len(_text) + lag_frames
 
-                # Draw the user's name above the text box
-                _character_name = character_name
-                _namebox_center = None
-                _namebox_right = None
-                if "name" in obj:
-                    _character_name = AnimText(
-                        obj["name"],
-                        font_path="assets/igiari/Igiari.ttf",
-                        font_size=12,
-                        x=6,
-                        y=129-11,
-                    )
-
-                    name_width = _character_name.get_text_size()[0]
-
-                    _namebox_center = AnimImg(
-                        "assets/textbox/nametag_center.png",
-                        x=3,
-                        y=129-12,
-                        w=name_width + 6,
-                        h=14
-                    )
-
-                    _namebox_right = AnimImg(
-                        "assets/textbox/nametag_right.png",
-                        x=3 + name_width + 6,
-                        y=129-12
-                    )
-
                 # Apply shake effect to the scene if desired
                 if obj["action"] == constants.Action.TEXT_SHAKE_EFFECT:
                     bg.shake_effect = True
@@ -208,7 +221,17 @@ def do_video(config: List[Dict], output_filename, resolution_scale):
                 scene_objs = list(
                     filter(
                         lambda x: x is not None,
-                        [bg, character, bench, textbox, namebox_l, _namebox_center, _namebox_right, _character_name, text, evidence],
+                        [
+                            bg,
+                            character,
+                            bench,
+                            textbox
+                        ]
+                        + create_nameplate(obj) +
+                        [
+                            text,
+                            evidence
+                        ]
                     )
                 )
                 scenes.append(
@@ -231,7 +254,7 @@ def do_video(config: List[Dict], output_filename, resolution_scale):
                 scene_objs = list(
                     filter(
                         lambda x: x is not None,
-                        [bg, character, bench, textbox, _character_name, text, arrow, evidence],
+                        [bg, character, bench, textbox] + create_nameplate(obj) + [text, arrow, evidence],
                     )
                 )
                 scenes.append(
@@ -256,8 +279,10 @@ def do_video(config: List[Dict], output_filename, resolution_scale):
                                 bg,
                                 character,
                                 bench,
-                                textbox,
-                                character_name,
+                                textbox
+                            ]
+                            + create_nameplate(obj) +
+                            [
                                 text,
                                 arrow,
                                 evidence,

--- a/objection_engine/beans/text.py
+++ b/objection_engine/beans/text.py
@@ -50,6 +50,7 @@ class AnimText:
         if ('size' in self.font):
             self.font_size = self.font['size']
         self.colour = colour
+        self.font_object = ImageFont.truetype(self.font_path, self.font_size)
 
     def render(self, background: Image, frame: int = 0):
         draw = ImageDraw.Draw(background)
@@ -57,11 +58,13 @@ class AnimText:
         if self.typewriter_effect:
             _text = _text[:frame]
         if self.font_path is not None:
-            font = ImageFont.truetype(self.font_path, self.font_size)
-            draw.text((self.x, self.y), _text, font=font, fill=self.colour)
+            draw.text((self.x, self.y), _text, font=self.font_object, fill=self.colour)
         else:
             draw.text((self.x, self.y), _text, fill=self.colour)
         return background
+
+    def get_text_size(self):
+        return self.font_object.getsize(self.text)
 
     def _select_best_font(self):
         best_font = self.font_array[-1]

--- a/objection_engine/utils.py
+++ b/objection_engine/utils.py
@@ -49,18 +49,18 @@ def get_characters(common: Counter, assigned_characters: dict = None):
     # If Phoenix was not manually assigned and the user with
     # the most comments wasn't manually assigned a character,
     # assign Phoenix to the user with the most comments.
-    if Character.PHOENIX not in users_to_characters.values() and most_common[0] not in users_to_characters:
-        try:
+    try:
+        if Character.PHOENIX not in users_to_characters.values() and most_common[0] not in users_to_characters:
             users_to_characters[most_common[0]] = Character.PHOENIX
-        except IndexError:
-            pass
+    except IndexError:
+        pass
 
     # Same for Edgeworth, but to the user with the second-most comments.
-    if Character.EDGEWORTH not in users_to_characters.values() and most_common[1] not in users_to_characters:
-        try:
+    try:
+        if Character.EDGEWORTH not in users_to_characters.values() and most_common[1] not in users_to_characters:
             users_to_characters[most_common[1]] = Character.EDGEWORTH
-        except IndexError:
-            pass
+    except IndexError:
+        pass
 
     # Finally, from the remaining pool of characters, let's assign them randomly
     # to the remaining user IDs.


### PR DESCRIPTION
This pull request implements two improvements to rendering:
- First, instead of being a static size, the nameplate box now adjusts its width to fit the name of whoever is speaking.
- Second, it tries to use the nameplate font recreation discussed in issue #22 before falling back to the other fonts.

To do the dynamic nameplate sizing, I did my best to recreate the dialogue box based on screenshots from the original DS games.

Here is a screenshot of a quick test dialogue before the pull request:
![Screen Shot 2022-10-22 at 8 56 22 PM](https://user-images.githubusercontent.com/9957987/197373128-9a4f735f-f559-4a5f-9fe3-b23d4cd4cea7.png)

And this is what the same dialogue looks like with these changes:
<img width="507" alt="Screen Shot 2022-10-22 at 9 10 23 PM" src="https://user-images.githubusercontent.com/9957987/197373330-d7bbb5a3-f8df-43f8-99a2-44192e2742b4.png">

In order for this to work, some additional assets will need to be added to the assets folder. [This zip file](https://github.com/LuisMayo/objection_engine/files/9845755/nameplate_assets.zip) includes:
- `ace_name` - folder with the font discussed in #22 for the nameplates
- `textbox` - folder with the PNGs for the text box and nameplate parts
- `AA dialogue box recreation.afphoto` - the raw Affinity Photo document with the dialogue box. If you'd like it in another format like PSD, I can certainly export it, but I don't know if any data will be lost.

They should just need to be placed in the `assets` folder (with the exception of the `.afphoto` file; it's just there so we can edit it later :) )

I've tested this with the `example.py` file as well as a few of my own short scripts, and it seems to be working well, but of course it'd be great to have other checks done before merging so it doesn't break anything.

Thanks so much!