### PR TITLE
Improved Arabic/RTL support

### DIFF
--- a/examples/test_rtl.py
+++ b/examples/test_rtl.py
@@ -3,9 +3,9 @@ from objection_engine.beans.comment import Comment
 from time import time
 
 comments = [
-    Comment(user_name = 'Phoenix', text_content="Here is some English LTR text"),
-    Comment(user_name = 'Phoenix', text_content="هذا نص عربي. أنا أستخدم مترجمًا ، لذلك ربما يكون الأمر سيئًا للغاية."),
-    Comment(user_name="Phoenix", text_content="الكلمة الأخيرة في هذه الجملة هي <red> أحمر </red>.")
+    Comment(user_name = 'Edgeworth', text_content="Here is some English LTR text"),
+    Comment(user_name = 'فينيكس', text_content="هذا نص عربي. أنا أستخدم مترجمًا ، لذلك ربما يكون الأمر سيئًا للغاية."),
+    Comment(user_name="فينيكس", text_content="الكلمة الأخيرة في هذه الجملة هي <red> أحمر </red>.")
 ]
 
 render_comment_list(comments, f'test-rtl-{str(int(time()))}.mp4', resolution_scale=2)

--- a/examples/test_rtl.py
+++ b/examples/test_rtl.py
@@ -1,0 +1,11 @@
+from objection_engine.renderer import render_comment_list
+from objection_engine.beans.comment import Comment
+from time import time
+
+comments = [
+    Comment(user_name = 'Phoenix', text_content="Here is some English LTR text"),
+    Comment(user_name = 'Phoenix', text_content="هذا نص عربي. أنا أستخدم مترجمًا ، لذلك ربما يكون الأمر سيئًا للغاية."),
+    Comment(user_name="Phoenix", text_content="الكلمة الأخيرة في هذه الجملة هي <red> أحمر </red>.")
+]
+
+render_comment_list(comments, f'test-rtl-{str(int(time()))}.mp4', resolution_scale=2)

--- a/objection_engine/anim.py
+++ b/objection_engine/anim.py
@@ -69,9 +69,9 @@ def create_nameplate(obj: dict):
     # If the text of the text box is RTL, then move
     # the nameplate to the right side of the screen
     if obj["text"].use_rtl():
-        namebox_l.x = 256 - 3 - name_width - 6
-        namebox_c.x = 256 - 3 - name_width - 3
-        namebox_r.x = 256 - 3
+        namebox_l.x = 256 - namebox_r.w - name_width - 6
+        namebox_c.x = 256 - namebox_r.w - name_width - 3
+        namebox_r.x = 256 - namebox_r.w
         character_name.x = namebox_l.x + 5
 
     if obj.get("action") == constants.Action.TEXT_SHAKE_EFFECT:

--- a/objection_engine/anim.py
+++ b/objection_engine/anim.py
@@ -92,8 +92,7 @@ def do_video(config: List[Dict], output_filename, resolution_scale):
     for scene in config:
         # We pick up the images to be rendered
         bg = AnimImg(constants.location_map[scene["location"]])
-        arrow_right = AnimImg("assets/arrow.png", x=235, y=170, w=15, h=15, key_x=5)
-        arrow_left = AnimImg("assets/arrow.png", x=5, y=170, w=15, h=15, key_x=5, flip_x=True)
+        arrow = AnimImg("assets/arrow.gif", x=235, y=170, w=15, h=15)
         textbox = AnimImg("assets/textbox/mainbox.png", x=1, y=129, w=bg.w-2)
         objection = AnimImg("assets/objection.gif")
         bench = None
@@ -115,6 +114,12 @@ def do_video(config: List[Dict], output_filename, resolution_scale):
         current_character_gender = "male"
         text = None
         for obj in scene["scene"]:
+            if obj["text"].use_rtl():
+                arrow.x = 7
+                arrow.flip_x = True
+            else:
+                arrow.x = 235
+                arrow.flip_x = False
             # First we check for evidences
             if "evidence" in obj and obj['evidence'] is not None:
                 if scene["location"] == constants.Location.COURTROOM_RIGHT:
@@ -237,7 +242,7 @@ def do_video(config: List[Dict], output_filename, resolution_scale):
                 scene_objs = list(
                     filter(
                         lambda x: x is not None,
-                        [bg, character, bench, textbox] + create_nameplate(obj) + [text, arrow_left if obj["text"].use_rtl() else arrow_right, evidence],
+                        [bg, character, bench, textbox] + create_nameplate(obj) + [text, arrow, evidence],
                     )
                 )
                 scenes.append(
@@ -267,7 +272,7 @@ def do_video(config: List[Dict], output_filename, resolution_scale):
                             + create_nameplate(obj) +
                             [
                                 text,
-                                arrow_left if obj["text"].use_rtl() else arrow_right,
+                                arrow,
                                 evidence,
                             ],
                         )

--- a/objection_engine/anim.py
+++ b/objection_engine/anim.py
@@ -66,6 +66,14 @@ def create_nameplate(obj: dict):
         y = 129 - 12
     )
 
+    # If the text of the text box is RTL, then move
+    # the nameplate to the right side of the screen
+    if obj["text"].use_rtl():
+        namebox_l.x = 256 - 3 - name_width - 6
+        namebox_c.x = 256 - 3 - name_width - 3
+        namebox_r.x = 256 - 3
+        character_name.x = namebox_l.x + 5
+
     if obj.get("action") == constants.Action.TEXT_SHAKE_EFFECT:
         namebox_l.shake_effect = True
         namebox_c.shake_effect = True

--- a/objection_engine/anim.py
+++ b/objection_engine/anim.py
@@ -114,7 +114,7 @@ def do_video(config: List[Dict], output_filename, resolution_scale):
         current_character_gender = "male"
         text = None
         for obj in scene["scene"]:
-            if obj["text"].use_rtl():
+            if "text" in obj and obj["text"].use_rtl():
                 arrow.x = 7
                 arrow.flip_x = True
             else:

--- a/objection_engine/anim.py
+++ b/objection_engine/anim.py
@@ -92,7 +92,8 @@ def do_video(config: List[Dict], output_filename, resolution_scale):
     for scene in config:
         # We pick up the images to be rendered
         bg = AnimImg(constants.location_map[scene["location"]])
-        arrow = AnimImg("assets/arrow.png", x=235, y=170, w=15, h=15, key_x=5)
+        arrow_right = AnimImg("assets/arrow.png", x=235, y=170, w=15, h=15, key_x=5)
+        arrow_left = AnimImg("assets/arrow.png", x=5, y=170, w=15, h=15, key_x=5, flip_x=True)
         textbox = AnimImg("assets/textbox/mainbox.png", x=1, y=129, w=bg.w-2)
         objection = AnimImg("assets/objection.gif")
         bench = None
@@ -236,7 +237,7 @@ def do_video(config: List[Dict], output_filename, resolution_scale):
                 scene_objs = list(
                     filter(
                         lambda x: x is not None,
-                        [bg, character, bench, textbox] + create_nameplate(obj) + [text, arrow, evidence],
+                        [bg, character, bench, textbox] + create_nameplate(obj) + [text, arrow_left if obj["text"].use_rtl() else arrow_right, evidence],
                     )
                 )
                 scenes.append(
@@ -266,7 +267,7 @@ def do_video(config: List[Dict], output_filename, resolution_scale):
                             + create_nameplate(obj) +
                             [
                                 text,
-                                arrow,
+                                arrow_left if obj["text"].use_rtl() else arrow_right,
                                 evidence,
                             ],
                         )

--- a/objection_engine/beans/font_constants.py
+++ b/objection_engine/beans/font_constants.py
@@ -12,6 +12,8 @@ FONT_ARRAY = [
         {'path': './assets/igiari/Galmuri11.ttf'},
         # Pixel, Kanji, Hiragana, Katakana
         {'path':'./assets/igiari/jackeyfont.ttf'},
+        # Better Arabic
+        {'path':'./assets/igiari/KawkabMono-Regular.ttf', 'size': 8, 'offset': {TextType.NAME: (0, -2)}, 'rtl': True},
         # Arabic
         {'path':'./assets/igiari/arabic-1.ttf', 'size': 12, 'offset': {TextType.NAME: (0, -5)}, 'rtl': True},
         # Pixel-font, Hebrew

--- a/objection_engine/beans/img.py
+++ b/objection_engine/beans/img.py
@@ -18,8 +18,6 @@ class AnimImg:
         y: int = 0,
         w: int = None,
         h: int = None,
-        key_x: int = None,
-        key_x_reverse: bool = True,
         shake_effect: bool = False,
         half_speed: bool = False,
         repeat: bool = True,
@@ -41,27 +39,8 @@ class AnimImg:
                 resized = self.resize(img, w=w, h=h)
                 converted = resized.convert('RGBA',palette=Image.ADAPTIVE)
                 self.frames.append(converted)
-        elif key_x is not None:
-            self.frames = []
-            for x_pad in range(key_x):
-                self.frames.append(
-                    add_margin(
-                        self.resize(img, w=w, h=h).convert("RGBA"), 0, x_pad if self.flip_x else 0, 0, x_pad if not self.flip_x else 0
-                    )
-                )
-            if key_x_reverse:
-                for x_pad in reversed(range(key_x)):
-                    self.frames.append(
-                        add_margin(
-                            self.resize(img, w=w, h=h).convert("RGBA"), 0, x_pad if self.flip_x else 0, 0, x_pad if not self.flip_x else 0
-                        )
-                    )
         else:
             self.frames = [self.resize(img, w=w, h=h).convert("RGBA")]
-
-        if self.flip_x:
-            for i in range(len(self.frames)):
-                self.frames[i] = ImageOps.mirror(self.frames[i])
 
         self.w = self.frames[0].size[0]
         self.h = self.frames[0].size[1]
@@ -104,6 +83,9 @@ class AnimImg:
         else:
             _background = background
         _img.convert("RGBA")
+
+        if self.flip_x:
+            _img = ImageOps.mirror(_img)
 
         bg_w, bg_h = _background.size
         offset = (self.x, self.y)

--- a/objection_engine/beans/img.py
+++ b/objection_engine/beans/img.py
@@ -1,4 +1,4 @@
-from PIL import Image
+from PIL import Image, ImageOps, ImageDraw
 import random as r
 
 def add_margin(pil_img, top, right, bottom, left):
@@ -24,13 +24,15 @@ class AnimImg:
         half_speed: bool = False,
         repeat: bool = True,
         maxw: int = None,
-        maxh: int = None
+        maxh: int = None,
+        flip_x: bool = False
     ):
         self.x = x
         self.y = y
         self.maxw = maxw
         self.maxh = maxh
         self.path = path
+        self.flip_x = flip_x
         img = Image.open(path, "r")
         if img.format == "GIF" and img.is_animated:
             self.frames = []
@@ -44,18 +46,23 @@ class AnimImg:
             for x_pad in range(key_x):
                 self.frames.append(
                     add_margin(
-                        self.resize(img, w=w, h=h).convert("RGBA"), 0, 0, 0, x_pad
+                        self.resize(img, w=w, h=h).convert("RGBA"), 0, x_pad if self.flip_x else 0, 0, x_pad if not self.flip_x else 0
                     )
                 )
             if key_x_reverse:
                 for x_pad in reversed(range(key_x)):
                     self.frames.append(
                         add_margin(
-                            self.resize(img, w=w, h=h).convert("RGBA"), 0, 0, 0, x_pad
+                            self.resize(img, w=w, h=h).convert("RGBA"), 0, x_pad if self.flip_x else 0, 0, x_pad if not self.flip_x else 0
                         )
                     )
         else:
             self.frames = [self.resize(img, w=w, h=h).convert("RGBA")]
+
+        if self.flip_x:
+            for i in range(len(self.frames)):
+                self.frames[i] = ImageOps.mirror(self.frames[i])
+
         self.w = self.frames[0].size[0]
         self.h = self.frames[0].size[1]
         self.shake_effect = shake_effect
@@ -97,6 +104,7 @@ class AnimImg:
         else:
             _background = background
         _img.convert("RGBA")
+
         bg_w, bg_h = _background.size
         offset = (self.x, self.y)
         # if there is a shake effect to be applied
@@ -104,7 +112,9 @@ class AnimImg:
         if self.shake_effect:
             offset = (self.x + r.randint(-1, 1), self.y + r.randint(-1, 1))
         # paste _img onto _background with offset
+
         _background.paste(_img, offset, mask=_img)
+
         if background is None:
             return _background
 

--- a/objection_engine/beans/text.py
+++ b/objection_engine/beans/text.py
@@ -78,7 +78,7 @@ class AnimText:
         elif isinstance(_text, DialoguePage):
             for line_no, line in enumerate(_text.lines):
                 if self.use_rtl:
-                    x_offset = 220
+                    x_offset = 256 - 11 - 11
                 else:
                     x_offset = 0
                 for chunk_no, chunk in enumerate(line):

--- a/objection_engine/parse_tags.py
+++ b/objection_engine/parse_tags.py
@@ -95,6 +95,10 @@ class DialoguePage:
             lines_of_chunks.append(chunks)
         return DialoguePage(lines_of_chunks)
 
+    def use_rtl(self):
+        best_font = get_best_font(self.get_raw_text(), FONT_ARRAY)
+        return best_font.get("rtl", False)
+
 @dataclass
 class DialogueTextContent:
     cleaned_lines: str

--- a/objection_engine/utils.py
+++ b/objection_engine/utils.py
@@ -21,10 +21,10 @@ def ensure_assets_are_available():
         updated_assets.append('arrow.gif')
         updated_assets.append('igiari/KawkabMono-Regular.ttf')
         for asset in updated_assets:
-            print(f'Assets present. but {asset} is missing, downloading')
             full_path = './assets/' + asset
             dl_path = 'https://dl.luismayo.com/objection_engine/' + asset
             if not os.path.isfile(full_path):
+                print(f'Assets present. but {asset} is missing, downloading')
                 response = requests.get(dl_path)
                 with open(full_path, 'wb') as file:
                     file.write(response.content)

--- a/objection_engine/utils.py
+++ b/objection_engine/utils.py
@@ -15,6 +15,20 @@ def ensure_assets_are_available():
         with zipfile.ZipFile('assets.zip', 'r') as zip_ref:
             zip_ref.extractall('assets')
         os.remove('assets.zip')
+    else:
+        # This is in case there are only some missing assets that have been added in updates
+        updated_assets = []
+        updated_assets.append('arrow.gif')
+        updated_assets.append('igiari/KawkabMono-Regular.ttf')
+        for asset in updated_assets:
+            print(f'Assets present. but {asset} is missing, downloading')
+            full_path = './assets/' + asset
+            dl_path = 'https://dl.luismayo.com/objection_engine/' + asset
+            if not os.path.isfile(full_path):
+                response = requests.get(dl_path)
+                with open(full_path, 'wb') as file:
+                    file.write(response.content)
+
 
 def get_characters(common: Counter, assigned_characters: dict = None):
     users_to_characters = {} if assigned_characters is None else assigned_characters.copy()


### PR DESCRIPTION
Implements issue #92.

- When the dialogue box renders its text as RTL, the nameplate moves to the right side of the screen, and the "next dialogue" arrow moves to the left side of the screen.
- The preferred font for Arabic text is changed to [Kawkab Mono](https://makkuk.com/kawkab-mono/#en), which may be more readable. The previous font still remains as a fallback option.
    - For some reason, as you can see in the video below Kawkab Mono performs its line breaks much sooner than the old font, causing text to only take up about half of the box... No modifications were made to the line-breaking code so I'm not sure why that would be. If this is an issue, we could revert the font change until we're able to implement a fix.

https://user-images.githubusercontent.com/9957987/200884824-132dc7f5-e993-4b20-a1e4-d9d81d27a947.mp4

NOTE: With these changes, the user will need to have the `KawkabMono-Regular.ttf` file from [the font's website](https://makkuk.com/kawkab-mono/#en) in the `assets/igiari` folder.